### PR TITLE
Fix link to ENAC4IT website

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -34,7 +34,7 @@ draft = false
     <h1>Participating</h1>
 
     <p>A team comprised of <a href="https://c4dt.epfl.ch">C4DT</a>,
-        <a href="https://go.epfl.ch/it4r">ENAC-IT4R</a>,
+        <a href="https://www.epfl.ch/schools/enac/about/data-at-enac/enac-it4research/">ENAC-IT4R</a>,
         and <a href="https://scitas.epfl.ch">SCITAS</a>
         started discussing how to set up a kickoff meeting.
     You can find more information <a href="/post/2024-02-08_preparation/">on our first blogpost</a>.</p>


### PR DESCRIPTION
There was a problem with the short link of ENAC-IT4R. The GO EPFL link points to the page in French, which doesn't seem to exist anymore. As a fix, I put the full address.